### PR TITLE
Bump bootstrap from 4.0.0 to 4.3.1 in /SMSTickerAlert

### DIFF
--- a/SMSTickerAlert/packages.config
+++ b/SMSTickerAlert/packages.config
@@ -3,7 +3,7 @@
   <package id="Antlr" version="3.5.0.2" targetFramework="net452" />
   <package id="AspNet.ScriptManager.bootstrap" version="4.0.0" targetFramework="net452" />
   <package id="AspNet.ScriptManager.jQuery" version="3.3.1" targetFramework="net452" />
-  <package id="bootstrap" version="4.0.0" targetFramework="net452" />
+  <package id="bootstrap" version="4.3.1" targetFramework="net452" />
   <package id="Bootswatch" version="4.0.0" targetFramework="net452" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
   <package id="jQuery" version="3.3.1" targetFramework="net452" />


### PR DESCRIPTION
Bumps bootstrap from 4.0.0 to 4.3.1.

Signed-off-by: dependabot[bot] <support@github.com>